### PR TITLE
Change to remove user/pass from cmdline (which is visible by all users)

### DIFF
--- a/aad-login
+++ b/aad-login
@@ -8,6 +8,9 @@
 # Early in /etc/pam.d/common-auth, add:
 #   auth sufficient pam_exec.so expose_authtok /usr/local/bin/aad-login
 
-read password
-node /opt/aad-login/aad-login.js $PAM_USER $password
+read aadpw
+export aaduser=$PAM_USER
+export aadpw
+
+node /opt/aad-login/aad-login.js
 exit $?

--- a/aad-login.js
+++ b/aad-login.js
@@ -14,8 +14,8 @@ if (!directory || !clientid) {
   process.exit(1);
 }
 
-var username = process.argv[2];
-var password = process.argv[3];
+var username = process.env.aaduser;
+var password = process.env.aadpw;
 
 if (username && password) {
   request = {


### PR DESCRIPTION
In a system that implements previous revisions, the credentials passed to the cmdline were leaked to the process table. A non-privileged user on the system could simply run a for loop  `while true;do ps -elf|grep [a]ad-login;done`  and collect user/pass combinations as users logged on.

By moving the credentials into an environment variable that is passed to node, it prevents this eavesdropping.